### PR TITLE
[WIP] add column onesignal on notification_settings

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -15,17 +15,11 @@ class NotificationsController < ApplicationController
   end
 
   def update
-    key, value =
-      case
-        when params[:email]  then [:email, params[:email]]
-        when params[:dm]     then [:dm, params[:dm]]
-        when params[:news]   then [:news, params[:news]]
-        when params[:search] then [:search, params[:search]]
-        when params[:update] then [:update, params[:update]]
-      end
-    value = value == 'true' ? true : false
+    attrs = %i(email dm news search updated)
+    key = attrs.find { |attr| params[attr] }
+    value = params[key] == 'true' ? true : false
     current_user.notification_setting.update!(key => value)
-    render json: current_user.notification_setting.attributes.slice('email', 'dm', 'news', 'search', 'update'), status: 200
+    render json: current_user.notification_setting.attributes.slice(*attrs), status: 200
   rescue => e
     logger.warn "#{self.class}##{__method__}: #{e.class} #{e.message} #{params.inspect}"
     render nothing: true, status: 500

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -21,10 +21,11 @@ class NotificationsController < ApplicationController
         when params[:dm]     then [:dm, params[:dm]]
         when params[:news]   then [:news, params[:news]]
         when params[:search] then [:search, params[:search]]
+        when params[:update] then [:update, params[:update]]
       end
     value = value == 'true' ? true : false
     current_user.notification_setting.update!(key => value)
-    render json: current_user.notification_setting.attributes.slice('email', 'dm', 'news', 'search'), status: 200
+    render json: current_user.notification_setting.attributes.slice('email', 'dm', 'news', 'search', 'update'), status: 200
   rescue => e
     logger.warn "#{self.class}##{__method__}: #{e.class} #{e.message} #{params.inspect}"
     render nothing: true, status: 500

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -26,47 +26,57 @@ class NotificationSetting < ActiveRecord::Base
   SEND_EMAIL_INTERVAL = 1.day
 
   def can_send_email?
-    email? && last_email_at.present? && last_email_at < SEND_EMAIL_INTERVAL.ago
-  end
-
-  def email_reset_at
-    last_email_at + SEND_EMAIL_INTERVAL
+    if respond_to?(:email_sent_at)
+      email? && email_sent_at.present? && email_sent_at < SEND_EMAIL_INTERVAL.ago
+    else
+      email? && last_email_at.present? && last_email_at < SEND_EMAIL_INTERVAL.ago
+    end
   end
 
   SEND_DM_INTERVAL = Rails.env.production? ? 12.hours : 1.minutes
 
   def can_send_dm?
-    dm? && last_dm_at.present? && last_dm_at < SEND_DM_INTERVAL.ago
-  end
-
-  def dm_reset_at
-    last_dm_at + SEND_DM_INTERVAL
+    if respond_to?(:dm_sent_at)
+      dm? && dm_sent_at.present? && dm_sent_at < SEND_DM_INTERVAL.ago
+    else
+      dm? && last_dm_at.present? && last_dm_at < SEND_DM_INTERVAL.ago
+    end
   end
 
   SEND_NEWS_INTERVAL = 1.day
 
   def can_send_news?
-    news? && last_news_at.present? && last_news_at < SEND_NEWS_INTERVAL.ago
-  end
-
-  def news_reset_at
-    last_news_at + SEND_NEWS_INTERVAL
+    if respond_to?(:news_sent_at)
+      news? && news_sent_at.present? && news_sent_at < SEND_NEWS_INTERVAL.ago
+    else
+      news? && last_news_at.present? && last_news_at < SEND_NEWS_INTERVAL.ago
+    end
   end
 
   SEND_SEARCH_INTERVAL = Rails.env.production? ? 60.minutes : 1.minutes
 
   def can_send_search?
-    search? && last_search_at.present? && last_search_at < SEND_SEARCH_INTERVAL.ago
+    if respond_to?(:search_sent_at)
+      search? && search_sent_at.present? && search_sent_at < SEND_SEARCH_INTERVAL.ago
+    else
+      search? && last_search_at.present? && last_search_at < SEND_SEARCH_INTERVAL.ago
+    end
   end
 
-  def search_reset_at
-    last_search_at + SEND_SEARCH_INTERVAL
+  SEND_UPDATE_INTERVAL = Rails.env.production? ? 60.minutes : 1.minutes
+
+  def can_send_update?
+    if respond_to?(:update_sent_at)
+      update? && update_sent_at.present? && update_sent_at < SEND_UPDATE_INTERVAL.ago
+    else
+      can_send_dm?
+    end
   end
 
   def can_send?(type)
     case type
       when :search then can_send_search?
-      when :update then can_send_dm?
+      when :update then (respond_to?(:can_send_update?) ? can_send_update? : can_send_dm?)
       else raise "#{self.class}##{__method__}: #{type} is not permitted."
     end
   end

--- a/app/models/notification_setting.rb
+++ b/app/models/notification_setting.rb
@@ -67,7 +67,7 @@ class NotificationSetting < ActiveRecord::Base
 
   def can_send_update?
     if respond_to?(:update_sent_at)
-      update? && update_sent_at.present? && update_sent_at < SEND_UPDATE_INTERVAL.ago
+      updated? && update_sent_at.present? && update_sent_at < SEND_UPDATE_INTERVAL.ago
     else
       can_send_dm?
     end
@@ -76,7 +76,7 @@ class NotificationSetting < ActiveRecord::Base
   def can_send?(type)
     case type
       when :search then can_send_search?
-      when :update then (respond_to?(:can_send_update?) ? can_send_update? : can_send_dm?)
+      when :update then can_send_update?
       else raise "#{self.class}##{__method__}: #{type} is not permitted."
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,33 +32,29 @@ class User < ActiveRecord::Base
 
   delegate :can_send?, to: :notification_setting
 
-  validates :uid, format: {with: Validations::UidValidator::REGEXP}
-  validates :screen_name, format: {with: Validations::ScreenNameValidator::REGEXP}
-  validates :secret, presence: true
-  validates :token, presence: true
-  validates :email, presence: true, allow_blank: true
-
   def self.update_or_create_for_oauth_by!(auth)
     attrs = {
       screen_name: auth.info.nickname,
       secret: auth.credentials.secret,
       token: auth.credentials.token
     }
-
-    user = User.find_or_initialize_by(uid: auth.uid)
-    if user.persisted?
-      attrs.update(email: auth.info.email) if auth.info.email.present?
-      user.update!(attrs)
-    else
-      attrs.update(email: auth.info.email || '')
-      user.assign_attributes(attrs)
+    if User.exists?(uid: auth.uid)
+      user = User.find_by(uid: auth.uid)
       self.transaction do
-        user.save!
+        user.update(attrs.update(email: (auth.info.email.present? ? auth.info.email : user.email)))
+        user.touch
+      end
+
+      yield(user, :update) if block_given?
+    else
+      user = nil
+      self.transaction do
+        user = User.create!(attrs.update(uid: auth.uid, email: (auth.info.email || '')))
         user.create_notification_setting!(last_email_at: 1.day.ago, last_dm_at: 1.day.ago, last_news_at: 1.day.ago, last_search_at: 1.day.ago)
       end
-    end
 
-    yield(user, :update) if block_given?
+      yield(user, :create) if block_given?
+    end
 
     user
   end

--- a/app/views/misc/_notification.html.erb
+++ b/app/views/misc/_notification.html.erb
@@ -1,0 +1,9 @@
+<div class="table-box">
+  <div class="table-cell-left">
+    <input id="<%= name %>-input" class="tgl tgl-ios" type="checkbox" value="1" <%= setting.send("#{name}?") ? 'checked="checked"'.html_safe : '' %> name="<%= name %>">
+    <label class='tgl-btn' for="<%= name %>-input"></label>
+  </div>
+  <div class="table-cell-right"><%= t("notifications.desc.#{name}") %>
+    <span style="display: none;" class="<%= name %> text-info blink small"><%= t('.updated') %></span>
+  </div>
+</div>

--- a/app/views/misc/menu.html.erb
+++ b/app/views/misc/menu.html.erb
@@ -2,18 +2,10 @@
 
 <div class="menu">
   <h2><small><%= t('notifications.setting') %></small></h2>
-  <% %i(email dm news search).each do |name| %>
-    <div class="table-box">
-      <div class="table-cell-left">
-        <input id="<%= name %>-input" class="tgl tgl-ios" type="checkbox" value="1" <%= user.notification_setting.send("#{name}?") ? 'checked="checked"'.html_safe : '' %> name="<%= name %>">
-        <label class='tgl-btn' for="<%= name %>-input"></label>
-      </div>
-      <div class="table-cell-right"><%= t("notifications.desc.#{name}") %>
-        <span style="display: none;" class="<%= name %> text-info blink small"><%= t('.updated') %></span>
-      </div>
-    </div>
-    <hr>
-  <% end %>
+  <h4><small><%= t('.notification.medium') %></small></h4>
+  <%= render partial: 'misc/notification', collection: %i(email dm), cached: true, as: :name, locals: {setting: user.notification_setting} %>
+  <h4><small><%= t('.notification.content') %></small></h4>
+  <%= render partial: 'misc/notification', collection: %i(news search update), cached: true, as: :name, locals: {setting: user.notification_setting} %>
   <script>
     function attach_event_handler(name) {
       var selector = 'input[name=' + name + ']';
@@ -37,6 +29,7 @@
       attach_event_handler('dm');
       attach_event_handler('news');
       attach_event_handler('search');
+      attach_event_handler('update');
     });
   </script>
 

--- a/app/views/misc/menu.html.erb
+++ b/app/views/misc/menu.html.erb
@@ -5,7 +5,7 @@
   <h4><small><%= t('.notification.medium') %></small></h4>
   <%= render partial: 'misc/notification', collection: %i(email dm), cached: true, as: :name, locals: {setting: user.notification_setting} %>
   <h4><small><%= t('.notification.content') %></small></h4>
-  <%= render partial: 'misc/notification', collection: %i(news search update), cached: true, as: :name, locals: {setting: user.notification_setting} %>
+  <%= render partial: 'misc/notification', collection: %i(news search updated), cached: true, as: :name, locals: {setting: user.notification_setting} %>
   <script>
     function attach_event_handler(name) {
       var selector = 'input[name=' + name + ']';
@@ -29,7 +29,7 @@
       attach_event_handler('dm');
       attach_event_handler('news');
       attach_event_handler('search');
-      attach_event_handler('update');
+      attach_event_handler('updated');
     });
   </script>
 

--- a/app/workers/create_notification_message_worker.rb
+++ b/app/workers/create_notification_message_worker.rb
@@ -45,6 +45,9 @@ class CreateNotificationMessageWorker
       dm = user.api_client.create_direct_message(user.uid.to_i, message)
       if notification.update(message_id: dm.id, message: message)
         user.notification_setting.touch(:last_search_at)
+        if user.notification_setting.respond_to?(:search_sent_at)
+          user.notification_setting.touch(:dm_sent_at, :search_sent_at)
+        end
         log.update(status: true, message: "[#{notification.id}] is created.")
       else
         log.update(status: false, message: "#{notification.errors.full_messages.join(', ')}.")
@@ -79,6 +82,9 @@ class CreateNotificationMessageWorker
       dm = user.api_client.create_direct_message(user.uid.to_i, message)
       if notification.update(message_id: dm.id, message: message)
         user.notification_setting.touch(:last_dm_at)
+        if user.notification_setting.respond_to?(:dm_sent_at)
+          user.notification_setting.touch(:dm_sent_at, :update_sent_at)
+        end
         log.update(status: true, message: "[#{notification.id}] is created.")
       else
         log.update(status: false, message: "#{notification.errors.full_messages.join(', ')}.")

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -163,10 +163,11 @@ ja:
       title: "%{user} への通知"
     setting: "通知設定"
     desc:
-      email: "フォローを外されたことをメールでお知らせ。配信はなる早です。"
-      dm: "フォローを外されたことをDMでお知らせ。配信はなる早です。"
+      email: "メールで通知する。"
+      dm: "DMで通知する。"
       news: "新機能のお知らせが届きます。配信は不定期です。"
-      search: "あなたのアカウントが検索されたことをDMでお知らせ。配信はなる早です。"
+      search: "他の人にえごったーで検索された時に通知します。配信はなる早です。"
+      update: "リムーブされたことを通知します。配信はなる早です。"
   login:
     welcome:
       lead: "ログインでえごったーが<br>もっと便利に！"
@@ -185,6 +186,10 @@ ja:
     menu:
       title: "メニュー"
       updated: "更新しました"
+      notification:
+        medium: "通知方法"
+        content: "通知内容"
+        interval: "通知間隔"
     terms_of_service:
       title: "利用規約"
     privacy_policy:

--- a/db/migrate/20160219123910_create_notification_settings.rb
+++ b/db/migrate/20160219123910_create_notification_settings.rb
@@ -1,18 +1,34 @@
 class CreateNotificationSettings < ActiveRecord::Migration
   def change
     create_table :notification_settings do |t|
-      t.boolean :email,           null: false, default: true
-      t.boolean :dm,              null: false, default: true
-      t.boolean :news,            null: false, default: true
-      t.boolean :search,          null: false, default: true
-      t.datetime :last_email_at,  null: false
-      t.datetime :last_dm_at,     null: false
-      t.datetime :last_news_at,   null: false
-      t.datetime :last_search_at, null: false
-      t.integer :from_id,         null: false
+      t.boolean :email,              null: false, default: true
+      t.boolean :dm,                 null: false, default: true
+      t.boolean :onesignal,          null: false, default: true # add
+      t.boolean :news,               null: false, default: true
+      t.boolean :search,             null: false, default: true
+      t.boolean :update,             null: false, default: true # add
+
+      t.datetime :last_email_at,     null: false
+      t.datetime :email_sent_at,     null: true # change
+
+      t.datetime :last_dm_at,        null: false
+      t.datetime :dm_sent_at,        null: true # change
+
+      t.datetime :onesignal_sent_at, null: true # add
+
+      t.datetime :last_news_at,      null: false
+      t.datetime :news_sent_at,      null: true # change
+
+      t.datetime :last_search_at,    null: false
+      t.datetime :search_sent_at,    null: true # change
+
+      t.datetime :update_sent_at,    null: true # add
+
+      t.integer :from_id,            null: false
 
       t.timestamps null: false
     end
-    add_index :notification_settings, :from_id
   end
+
+  add_index :notification_settings, :from_id, unique: true
 end

--- a/lib/tasks/notification_settings.rake
+++ b/lib/tasks/notification_settings.rake
@@ -1,0 +1,18 @@
+namespace :notification_settings do
+  desc 'backup'
+  task backup: :environment do
+    ActiveRecord::Base.connection.execute("CREATE TABLE old_notification_settings LIKE notification_settings")
+    ActiveRecord::Base.connection.execute("INSERT INTO old_notification_settings SELECT * FROM notification_settings")
+  end
+
+  desc 'copy'
+  task copy: :environment do
+    settings = NotificationSetting.all
+    settings.each do |s|
+      s.update = s.dm
+      s.search_sent_at = s.last_search_at
+      s.update_sent_at = s.last_dm_at
+    end
+    NotificationSetting.import settings, validate: false, timestamps: false
+  end
+end

--- a/lib/tasks/notification_settings.rake
+++ b/lib/tasks/notification_settings.rake
@@ -5,13 +5,14 @@ namespace :notification_settings do
     ActiveRecord::Base.connection.execute("INSERT INTO old_notification_settings SELECT * FROM notification_settings")
   end
 
-  desc 'copy'
-  task copy: :environment do
+  desc 'migrate'
+  task migrate: :environment do
     settings = NotificationSetting.all
     settings.each do |s|
-      s.update = s.dm
+      s.updated = s.dm
       s.search_sent_at = s.last_search_at
       s.update_sent_at = s.last_dm_at
+      # last_email_at is not used
     end
     NotificationSetting.import settings, validate: false, timestamps: false
   end


### PR DESCRIPTION
### Add columns

- [ ] done

```
ALTER TABLE notification_settings
  -- email
  -- dm
  ADD COLUMN onesignal         tinyint(1) NOT NULL DEFAULT '1' AFTER dm,
  -- news
  -- search
  ADD COLUMN updated           tinyint(1) NOT NULL DEFAULT '1' AFTER search,
  -- last_email_at
  ADD COLUMN email_sent_at     datetime                        AFTER last_email_at,
  -- last_dm_at
  ADD COLUMN dm_sent_at        datetime                        AFTER last_dm_at,
  ADD COLUMN onesignal_sent_at datetime                        AFTER dm_sent_at,
  -- last_search_at
  ADD COLUMN search_sent_at    datetime                        AFTER last_search_at,
  ADD COLUMN update_sent_at    datetime                        AFTER search_sent_at;
```

### Add unique index on from_id

- [x] done

```
ALTER TABLE notification_settings
  DROP INDEX index_notifications_on_from_id,
  ADD UNIQUE KEY index_notifications_on_from_id(from_id);
```

### Migrate values

- [ ] done

```
be rake notification_settings:migrate
```

### Drop columns

- [ ] done

```
ALTER TABLE notification_settings
  DROP COLUMN last_email_at,
  DROP COLUMN last_dm_at,
  DROP COLUMN last_search_at;
```

### TODO

- [x] add `prompt_report`
- [x] rename from from_id to user_id
- [ ] modifiable interval
- [ ] auto delete option